### PR TITLE
Draft: Rework unlock manager so it is no longer prone to race conditions

### DIFF
--- a/FreeAPS/Sources/Modules/Bolus/BolusStateModel.swift
+++ b/FreeAPS/Sources/Modules/Bolus/BolusStateModel.swift
@@ -241,13 +241,12 @@ extension Bolus {
 
             let maxAmount = Double(min(amount, provider.pumpSettings().maxBolus))
 
-            unlockmanager.unlock()
-                .sink { _ in } receiveValue: { [weak self] _ in
-                    guard let self = self else { return }
+            unlockmanager.unlock { authenticated in
+                if authenticated {
                     self.apsManager.enactBolus(amount: maxAmount, isSMB: false)
                     self.showModal(for: nil)
                 }
-                .store(in: &lifetime)
+            }
         }
 
         func setupInsulinRequired() {


### PR DESCRIPTION
This is the early beginnings of reworking the unlock manager so that it will no longer be prone to race conditions.

Improvements that must be made:
- Error handling
- Checking if we can at all evaluate the policy as per my comment in UnlockManager.swift

Improvements I'd like to make:
- Async instead of callbacks